### PR TITLE
Change <import> to <link> in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then use your Ractive components via `require()`:
 
 ```html
 <!-- mycomponent.html -->
-<import rel="ractive" href="./subcomponent.html">
+<link rel="ractive" href="./subcomponent.html">
 
 <div>Hello {{subject}}!</div>
 <subcomponent></subcomponent>


### PR DESCRIPTION
Subcomponents are referenced with `<link>` and not with import. `test.js` does it like this and the Ractive component spec at https://github.com/ractivejs/component-spec/blob/master/implementers.md#link-tags says the same.
This commit corrects the README
